### PR TITLE
Added fields to Makefile.PL

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,3 +1,7 @@
+NEXT
+	o Added AUTHOR, LICENSE and ABSTRACT fields to Makefile.PL
+	o Fixed 'Artistic' typo in Makefile.PL
+
 0.08
 	o applied patches by Per Carlson:
 	  - don't die on 1st error, rather collect them and

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -3,7 +3,7 @@
 #
 # Copyright (c) 2007-2014 T. v.Dein <tom |AT| cpan.org>.
 # All Rights Reserved. Std. disclaimer applies.
-# Artificial License, same as perl itself. Have fun.
+# Artistic License, same as perl itself. Have fun.
 #
 
 use ExtUtils::MakeMaker;
@@ -11,6 +11,12 @@ use ExtUtils::MakeMaker;
 WriteMakefile(
 	      NAME	   => 'Data::Validate::Struct',
 	      VERSION_FROM => 'Struct.pm',
+              ABSTRACT     => 'Validate recursive hash structures',
+              LICENSE      => 'perl',
+              AUTHOR       => [
+                'Thomas v.Dein <tom@cpan.org>',
+                'Per Carlson <pelle@cpan.org>',
+              ],
 	      clean        => { FILES => '*~ */*~' },
 	      PREREQ_PM    => { 
                 'Regexp::Common' => 0,


### PR DESCRIPTION
Hi Thomas.

I started preparing an [ITP](https://wiki.debian.org/ITP) bug in Debian, when I discovered some vital info was missing in Makefile.PL (and thus also in META-files). Debian is **very** strict about licensing and copyright, and both must be 100% clear before anything is accepted. Without this info in the package, it will be instantly rejected.

Added myself in the AUTHOR to make it match the POD.

Found also an 'Artificial' typo in the Makefile.PL.

It would be nice if you would accept those changes, so I can push forward with my ITP.
