### PR TITLE
Updated MANIFEST/META.* to match the 0.09 distribution.

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -4,3 +4,4 @@ Struct.pm
 README
 Changelog
 META.yml                                 Module meta-data (added by MakeMaker)
+META.json                                Module JSON meta-data (added by MakeMaker)

--- a/META.json
+++ b/META.json
@@ -1,12 +1,13 @@
 {
-   "abstract" : "unknown",
+   "abstract" : "Validate recursive hash structures",
    "author" : [
-      "unknown"
+      "Thomas v.Dein <tom@cpan.org>",
+      "Per Carlson <pelle@cpan.org>"
    ],
    "dynamic_config" : 1,
-   "generated_by" : "ExtUtils::MakeMaker version 6.66, CPAN::Meta::Converter version 2.130880",
+   "generated_by" : "ExtUtils::MakeMaker version 7.02, CPAN::Meta::Converter version 2.142690",
    "license" : [
-      "unknown"
+      "perl_5"
    ],
    "meta-spec" : {
       "url" : "http://search.cpan.org/perldoc?CPAN::Meta::Spec",
@@ -44,5 +45,5 @@
          "url" : "https://github.com/TLINDEN/Data-Validate-Struct"
       }
    },
-   "version" : "0.08"
+   "version" : "0.09"
 }

--- a/META.yml
+++ b/META.yml
@@ -1,26 +1,27 @@
 ---
-abstract: unknown
+abstract: 'Validate recursive hash structures'
 author:
-  - unknown
+  - 'Thomas v.Dein <tom@cpan.org>'
+  - 'Per Carlson <pelle@cpan.org>'
 build_requires:
-  ExtUtils::MakeMaker: 0
+  ExtUtils::MakeMaker: '0'
 configure_requires:
-  ExtUtils::MakeMaker: 0
+  ExtUtils::MakeMaker: '0'
 dynamic_config: 1
-generated_by: 'ExtUtils::MakeMaker version 6.66, CPAN::Meta::Converter version 2.130880'
-license: unknown
+generated_by: 'ExtUtils::MakeMaker version 7.02, CPAN::Meta::Converter version 2.142690'
+license: perl
 meta-spec:
   url: http://module-build.sourceforge.net/META-spec-v1.4.html
-  version: 1.4
+  version: '1.4'
 name: Data-Validate-Struct
 no_index:
   directory:
     - t
     - inc
 requires:
-  Data::Validate: 0.06
-  Data::Validate::IP: 0.18
-  Regexp::Common: 0
+  Data::Validate: '0.06'
+  Data::Validate::IP: '0.18'
+  Regexp::Common: '0'
 resources:
   repository: https://github.com/TLINDEN/Data-Validate-Struct
-version: 0.08
+version: '0.09'


### PR DESCRIPTION

The https://cpan.metacpan.org/authors/id/T/TL/TLINDEN/Data-Validate-Struct-0.09.tar.gz
official distribution file contains **MANIFEST**, **META.json**,
and **META.yml** files which are appropriate for **0.09**.

However these files are newer than those in
https://github.com/TLINDEN/Data-Validate-Struct, which
still contain the **0.08** versions of these files.  The github files
are also 3 months old as opposed to the 2 month old commit time
for the other changed 0.09 files.

It appears that these files were updated and included in the .tar.gz
distribution file but did not get added/committed in git.

This commit takes the versions of these 3 files from the official
*Data-Validate-Struct-0.09.tar.gz* distribution and adds/commits
them within git.  This should restore syncronization between the
github repository and the existing official release.