### PR TITLE
Do not die when comparing hash with array

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -3,6 +3,8 @@
 
 	o added cpanfile
 
+	o don't die when reference types are different
+
 0.10
 	o fixed RT#101884
 	  - _trim() only removed 1st whitespace
@@ -14,7 +16,7 @@
 
 	o fixed cached errors bug - if a validator object has
 	  been used multiple times and if during the first
-	  run some errors occured, subsequent runs would show
+	  run some errors occurred, subsequent runs would show
 	  the same error again and again.
 
 0.08

--- a/Struct.pm
+++ b/Struct.pm
@@ -195,7 +195,14 @@ sub _traverse {
   my ($self, $reference, $hash, @tree) = @_;
 
   foreach my $key (keys %{$reference}) {
-    if (ref($reference->{$key}) eq 'ARRAY') {
+    my $reference_ref = ref $reference->{$key};
+    my $hash_ref = ref $hash->{$key};
+    if ($reference_ref =~ /^ARRAY|HASH$/ && $reference_ref ne $hash_ref)
+    {
+      my $err = sprintf("Different structure types %s vs %s", $reference_ref, $hash_ref);
+      push @{$self->{errors}}, sprintf(q{%s at '%s'}, $err, join(' => ', @tree));
+    }
+    elsif ($reference_ref eq 'ARRAY') {
       # just use the 1st one, more elements in array are expected to be the same
       foreach my $item (@{$hash->{$key}}) {
         if (ref($item) eq q(HASH)) {
@@ -212,10 +219,10 @@ sub _traverse {
         }
       }
     }
-    elsif (ref($reference->{$key}) eq 'HASH') {
+    elsif ($reference_ref eq 'HASH') {
       $self->_traverse($reference->{$key}, $hash->{$key}, @tree, $key);
     }
-    elsif (ref($reference->{$key}) eq '') {
+    elsif ($reference_ref eq '') {
       $self->_debug("Checking $key at " . join(', ', @tree));
       if (my $err = $self->_check_type($key, $reference, $hash)) {
         push @{$self->{errors}}, sprintf(q{%s at '%s'}, $err, join(' => ', @tree));

--- a/t/run.t
+++ b/t/run.t
@@ -126,7 +126,7 @@ my $cfg =  {
 
 my $v = new_ok('Data::Validate::Struct', [ $ref ]);
 ok ($v->validate($cfg), "validate a reference against a OK config");
-
+print STDERR "\n\n\n",$v->errstr(),"\n\n\n";
 
 
 # check failure matching
@@ -400,6 +400,10 @@ ok($v3->validate($cfg3), "using custom types");
 my $v4 = Data::Validate::Struct->new({age => 'int'});
 ok(!$v4->validate({age => 'eight'}), "cache check first run, error");
 ok($v4->validate({age => 8}), "cache check second run, no error");
+
+# different references
+my $v5 = Data::Validate::Struct->new({ foo => [{bar => 'int'}]});
+ok(!$v5->validate({foo=>{bar=>10}}));
 
 done_testing();
 

--- a/t/run.t
+++ b/t/run.t
@@ -126,7 +126,7 @@ my $cfg =  {
 
 my $v = new_ok('Data::Validate::Struct', [ $ref ]);
 ok ($v->validate($cfg), "validate a reference against a OK config");
-print STDERR "\n\n\n",$v->errstr(),"\n\n\n";
+
 
 
 # check failure matching


### PR DESCRIPTION
When reference and struct differ on reference type, do not die, but rather collect the error.

I would welcome a release after this fix.