### PR TITLE
Do not create hash entries during validate.

### DIFF
--- a/Struct.pm
+++ b/Struct.pm
@@ -196,8 +196,8 @@ sub _traverse {
 
   foreach my $key (keys %{$reference}) {
     my $reference_ref = ref $reference->{$key};
-    my $hash_ref = ref $hash->{$key};
-    if ($reference_ref =~ /^ARRAY|HASH$/ && $reference_ref ne $hash_ref)
+    my $hash_ref = exists $hash->{$key} && ref $hash->{$key};
+    if ($hash_ref && $reference_ref =~ /^ARRAY|HASH$/ && $reference_ref ne $hash_ref)
     {
       my $err = sprintf("Different structure types %s vs %s", $reference_ref, $hash_ref);
       push @{$self->{errors}}, sprintf(q{%s at '%s'}, $err, join(' => ', @tree));


### PR DESCRIPTION
The new hash ref check in Data::Validate::Struct version 0.11 unconditionally accesses the fields in the hash to be validated. If the key does not exists, the config tree given to validate() changes when reading the reference type of the non nonexistent value.  Only do the type check if the subtree exists.  This restores old behavior of 0.10 and tests of my OSPF::LSDB module pass again.